### PR TITLE
fix MV JitterCancellation missing upscale factor

### DIFF
--- a/src/ffx-fsr2-api/ffx_fsr2.cpp
+++ b/src/ffx-fsr2-api/ffx_fsr2.cpp
@@ -663,8 +663,8 @@ static FfxErrorCode fsr2Dispatch(FfxFsr2Context_Private* context, const FfxFsr2D
     // compute jitter cancellation
     if (context->contextDescription.flags & FFX_FSR2_ENABLE_MOTION_VECTORS_JITTER_CANCELLATION) {
 
-        context->constants.motionVectorJitterCancellation[0] = (context->previousJitterOffset[0] - context->constants.jitterOffset[0]) / motionVectorsTargetSize[0];
-        context->constants.motionVectorJitterCancellation[1] = (context->previousJitterOffset[1] - context->constants.jitterOffset[1]) / motionVectorsTargetSize[1];
+        context->constants.motionVectorJitterCancellation[0] = (context->previousJitterOffset[0] - context->constants.jitterOffset[0]) / motionVectorsTargetSize[0] * context->constants.motionVectorScale[0];
+        context->constants.motionVectorJitterCancellation[1] = (context->previousJitterOffset[1] - context->constants.jitterOffset[1]) / motionVectorsTargetSize[1] * context->constants.motionVectorScale[1];
 
         context->previousJitterOffset[0] = context->constants.jitterOffset[0];
         context->previousJitterOffset[1] = context->constants.jitterOffset[1];


### PR DESCRIPTION
mentioned and fix by @BartmanAbyss  [here](https://github.com/GPUOpen-Effects/FidelityFX-FSR2/issues/39)